### PR TITLE
ci: upgrade actions/checkout to v4 and add PR triggers

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: swift-actions/setup-swift@v1
       - name: git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: docbuild
         run: >
           sudo xcode-select -s /Applications/Xcode_16.0.app;
@@ -32,9 +32,9 @@ jobs:
           echo "<script>window.location.href +=
           \"/documentation/later\"</script>" > docs/index.html;
       - name: artifacts
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs
       - name: deploy
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: 16.0
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -6,6 +6,8 @@ name: Ubuntu
 on:
   push:
     branches: ["**"]
+  pull_request:
+    branches: ["main"]
 
 jobs:
   build:
@@ -15,7 +17,7 @@ jobs:
       - uses: sersoft-gmbh/swifty-linux-action@v3
         with:
           release-version: 6.0
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build for release
         run: swift build -v -c release
       - name: Test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,6 +3,8 @@ name: Windows
 on:
   push:
     branches: ["**"]
+  pull_request:
+    branches: ["main"]
 
 jobs:
   build:
@@ -13,6 +15,6 @@ jobs:
           branch: swift-6.0-release
           tag: 6.0-RELEASE
   
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: swift build
       - run: swift test


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` from v3 to v4 (docc, macOS, ubuntu) and v2 to v4 (windows)
- Add `pull_request` triggers targeting `main` to ubuntu and windows workflows so CI runs on PRs
- Upgrade `actions/upload-pages-artifact` from v1 to v3 and `actions/deploy-pages` from v1 to v4 in the docc workflow
- macOS already had a PR trigger; docc is kept as push-to-main only (it deploys GitHub Pages)

Closes #24

## Test plan

- [ ] Verify macOS workflow runs on this PR
- [ ] Verify ubuntu workflow runs on this PR
- [ ] Verify windows workflow runs on this PR
- [ ] Confirm docc workflow does not run on PR (push-to-main only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)