### PR TITLE
Make Network Sendable and update for Swift 6

### DIFF
--- a/Sources/Later/Network/API.swift
+++ b/Sources/Later/Network/API.swift
@@ -4,7 +4,7 @@ import FoundationNetworking
 #endif
 
 /// An open class that defines the base API. It will request data from a network pointing to a specific API endpoint.
-open class API<APIEndpoint: Endpoint> {
+open class API<APIEndpoint: Endpoint>: @unchecked Sendable {
     private let network: Networking
 
     /// Initializes a new instance of the API class.

--- a/Sources/Later/Network/DataResponse.swift
+++ b/Sources/Later/Network/DataResponse.swift
@@ -4,7 +4,7 @@ import FoundationNetworking
 #endif
 
 /// Represents a response containing data and a URL response.
-public struct DataResponse {
+public struct DataResponse: Sendable {
     /// The data received in the response.
     public let data: Data?
 

--- a/Sources/Later/Network/Endpoint.swift
+++ b/Sources/Later/Network/Endpoint.swift
@@ -16,7 +16,7 @@ import FoundationNetworking
     - `headers`: The HTTP headers to include in the request.
     - `body`: The body of the HTTP request, if any.
  */
-public protocol Endpoint: Hashable {
+public protocol Endpoint: Hashable, Sendable {
     /// The base URL for the endpoint.
     static var url: URL { get }
 

--- a/Sources/Later/Network/HTTPRequestMethod.swift
+++ b/Sources/Later/Network/HTTPRequestMethod.swift
@@ -1,5 +1,5 @@
 /// Represents HTTP request methods.
-public enum HTTPRequestMethod: String {
+public enum HTTPRequestMethod: String, Sendable {
     /// The HTTP GET method.
     case GET
 

--- a/Sources/Later/Network/MockAPI.swift
+++ b/Sources/Later/Network/MockAPI.swift
@@ -15,7 +15,7 @@
 
  This will return a mock response using the data provided in the mockEndpoint body.
  */
-open class MockAPI<APIEndpoint: Endpoint>: API<APIEndpoint> {
+open class MockAPI<APIEndpoint: Endpoint>: API<APIEndpoint>, @unchecked Sendable {
     /**
 
     Sends an asynchronous network request to a specific API endpoint using a mock network.

--- a/Sources/Later/Network/MockNetwork.swift
+++ b/Sources/Later/Network/MockNetwork.swift
@@ -4,7 +4,7 @@ import FoundationNetworking
 #endif
 
 /// A class that implements the `Networking` protocol to provide mock network responses.
-open class MockNetwork: Network {
+open class MockNetwork: Network, @unchecked Sendable {
     private let responseData: Data?
     private let response: URLResponse?
 

--- a/Sources/Later/Network/Network.swift
+++ b/Sources/Later/Network/Network.swift
@@ -4,7 +4,7 @@ import FoundationNetworking
 #endif
 
 /// A class that implements the `Networking` protocol to perform network requests using URLSession.
-open class Network: Networking {
+open class Network: Networking, @unchecked Sendable {
     public weak var delegate: URLSessionTaskDelegate?
 
     public init(delegate: URLSessionTaskDelegate? = nil) {

--- a/Sources/Later/Network/Networking.swift
+++ b/Sources/Later/Network/Networking.swift
@@ -4,7 +4,7 @@ import FoundationNetworking
 #endif
 
 /// A protocol defining networking methods for making HTTP requests.
-public protocol Networking {
+public protocol Networking: Sendable {
     /// Sends an HTTP request to the specified URL.
     /// - Parameters:
     ///   - url: The URL to which the request will be sent.


### PR DESCRIPTION
## Summary
- Add `Sendable` conformance to all Network types (`DataResponse`, `HTTPRequestMethod`, `Networking`, `Endpoint`)
- Make `Network`, `MockNetwork`, `API`, and `MockAPI` conform to `@unchecked Sendable` (open classes require `@unchecked`)
- Enables safe use of Network types across concurrency boundaries in Swift 6

## Changes
| Type | Conformance | Reason |
|------|------------|--------|
| `DataResponse` | `Sendable` | Struct with `Data?` and `URLResponse?` (both Sendable) |
| `HTTPRequestMethod` | `Sendable` | Enum with `String` raw value |
| `Networking` | `Sendable` | Protocol requirement for conforming types |
| `Endpoint` | `Sendable` | Protocol requirement for conforming types |
| `Network` | `@unchecked Sendable` | Open class with `weak var delegate` |
| `MockNetwork` | `@unchecked Sendable` | Open subclass of Network |
| `API` | `@unchecked Sendable` | Open generic class with `let network` |
| `MockAPI` | `@unchecked Sendable` | Open subclass of API |

## Test plan
- [x] `swift build` passes with zero warnings
- [ ] CI runs tests on macOS, Ubuntu, and Windows

Fixes #26